### PR TITLE
Removed TravisCI badge as project is no longer built there

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# harn-framework [![Build Status](https://travis-ci.org/jhawlwut/harn-framework.svg?branch=travis-build)](https://travis-ci.org/jhawlwut/harn-framework)
+# harn-framework
 HapiJS, ArangoDB, ReactJS, and NodeJS boilerplate for rapid prototypes and getting you to MVP state... enterprise ready
 
 ## Why?


### PR DESCRIPTION
Removed the TravisCI badge from README as it didn't show correct status anymore.
